### PR TITLE
Port ZerotoKoops' audio macros to the main oracles-disasm repo

### DIFF
--- a/audio/ages/sfx/monkey.s
+++ b/audio/ages/sfx/monkey.s
@@ -3,9 +3,9 @@ sndMonkeyStart:
 sndMonkeyChannel2:
 	duty $00
 	vol $a
-	cmdf8 $0a
+	pitchSlide $0a
 	note c6  $05
-	cmdf8 $00
+	pitchSlide $00
 	cmdff
 
 .define sndMonkeyChannel7 MUSIC_CHANNEL_FALLBACK EXPORT

--- a/audio/ages/sfx/openGate.s
+++ b/audio/ages/sfx/openGate.s
@@ -3,7 +3,7 @@ sndOpenGateStart:
 sndOpenGateChannel2:
 	duty $01
 	vol $a
-	cmdf8 $ce
+	pitchSlide $ce
 	note cs3 $05
 	cmdff
 

--- a/audio/ages/sfx/switch2.s
+++ b/audio/ages/sfx/switch2.s
@@ -4,7 +4,7 @@ sndSwitch2Channel2:
 	duty $02
 	vol $d
 	env $1 $00
-	cmdf8 $00
+	pitchSlide $00
 	note c5  $04
 	vol $c
 	note e5  $04

--- a/audio/ages/sfx/timewarpInitiated.s
+++ b/audio/ages/sfx/timewarpInitiated.s
@@ -346,7 +346,7 @@ sndTimewarpInitiatedChannel2:
 
 sndTimewarpInitiatedChannel3:
 	duty $01
-	cmdfd $ff
+	pitchOffset -$01
 	vol $0
 	note gs3 $0d
 	vol $1
@@ -379,7 +379,7 @@ sndTimewarpInitiatedChannel3:
 	rest $0a
 	duty $00
 	env $2 $00
-	cmdfd $00
+	pitchOffset $00
 	vol $5
 	note c7  $0d
 	vol $2

--- a/audio/ages/sfx/tingle.s
+++ b/audio/ages/sfx/tingle.s
@@ -2,13 +2,13 @@ sndTingleStart:
 
 sndTingleChannel2:
 	duty $01
-	cmdf8 $fc
+	pitchSlide $fc
 	vol $b
 	note ds4 $05
 	rest $01
 	vol $0
 	note ds4 $01
-	cmdf8 $02
+	pitchSlide $02
 	env $0 $07
 	vol $a
 	note ds4 $46
@@ -19,7 +19,7 @@ sndTingleChannel2:
 	note f5  $01
 	vol $b
 	note fs5 $05
-	cmdf8 $fc
+	pitchSlide $fc
 	env $0 $02
 	vol $b
 	note fs5 $17

--- a/audio/ages/sfx/tokay.s
+++ b/audio/ages/sfx/tokay.s
@@ -2,7 +2,7 @@ sndTokayStart:
 
 sndTokayChannel2:
 	duty $00
-	cmdf8 $ba
+	pitchSlide $ba
 	vol $7
 	note as3 $02
 	vol $8

--- a/audio/ages/sfx/wind.s
+++ b/audio/ages/sfx/wind.s
@@ -79,14 +79,14 @@ sndWindChannel7:
 	cmdff
 	duty $00
 	vol $9
-	cmdf8 $7f
+	pitchSlide $7f
 	note d3  $03
-	cmdf8 $00
-	cmdf8 $81
+	pitchSlide $00
+	pitchSlide $81
 	note a3  $03
-	cmdf8 $00
+	pitchSlide $00
 	vol $f
-	cmdf8 $ef
+	pitchSlide $ef
 	note a2  $32
 	cmdff
 	cmdf0 $40

--- a/audio/common/mus/rosaDate.s
+++ b/audio/common/mus/rosaDate.s
@@ -259,7 +259,7 @@ musRosaDateChannel0:
 	env $0 $00
 	duty $02
 musicf5b54:
-	cmdfd $ff
+	pitchOffset -$01
 	vol $0
 	note gs3 $bd
 	vol $3
@@ -347,7 +347,7 @@ musicf5b54:
 	vol $1
 	note b5  $07
 	rest $2e
-	cmdfd $00
+	pitchOffset $00
 	vol $6
 	note cs6 $04
 	note ds6 $05

--- a/audio/common/mus/syrup.s
+++ b/audio/common/mus/syrup.s
@@ -65,17 +65,17 @@ musicf8251:
 	vol $3
 	note as7 $01
 	note as5 $01
-	cmdf8 $81
+	pitchSlide $81
 	note cs5 $03
-	cmdf8 $00
+	pitchSlide $00
 	vol $0
 	rest $05
 	vol $3
 	note as7 $01
 	note as5 $01
-	cmdf8 $81
+	pitchSlide $81
 	note cs5 $03
-	cmdf8 $00
+	pitchSlide $00
 	vol $0
 	rest $05
 	goto musicf8251

--- a/audio/common/sfx/aquamentusHover.s
+++ b/audio/common/sfx/aquamentusHover.s
@@ -4,44 +4,44 @@ sndAquamentusHoverChannel2:
 	duty $01
 musice9a8c:
 	vol $9
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $b
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $e
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $9
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $8
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $7
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $6
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $5
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $4
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $3
-	cmdf8 $64
+	pitchSlide $64
 	note b2  $04
-	cmdf8 $00
+	pitchSlide $00
 	goto musice9a8c
 	cmdff

--- a/audio/common/sfx/baseball.s
+++ b/audio/common/sfx/baseball.s
@@ -2,7 +2,7 @@ sndBaseballStart:
 
 sndBaseballChannel2:
 	cmdf0 $80
-	cmdf8 $1e
+	pitchSlide $1e
 	vol $d
 	.db $07 $4f $01
 	vol $0

--- a/audio/common/sfx/bombLand.s
+++ b/audio/common/sfx/bombLand.s
@@ -3,10 +3,10 @@ sndBombLandStart:
 sndBombLandChannel2:
 	duty $02
 	vol $d
-	cmdf8 $7f
+	pitchSlide $7f
 	note e2  $05
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
-	cmdf8 $81
+	pitchSlide $81
 	note cs3 $05
 	cmdff

--- a/audio/common/sfx/circling.s
+++ b/audio/common/sfx/circling.s
@@ -3,273 +3,273 @@ sndCirclingStart:
 sndCirclingChannel2:
 	duty $00
 	vol $1
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $2
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $3
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $4
-	cmdf8 $03
+	pitchSlide $03
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $5
-	cmdf8 $03
+	pitchSlide $03
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $6
-	cmdf8 $03
+	pitchSlide $03
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $7
-	cmdf8 $04
+	pitchSlide $04
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $7
-	cmdf8 $04
+	pitchSlide $04
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $7
-	cmdf8 $04
+	pitchSlide $04
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $6
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $6
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $6
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $5
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $5
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $5
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $4
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $4
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $4
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $3
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $3
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $3
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $2
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $2
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $2
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $1
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $1
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	vol $1
-	cmdf8 $05
+	pitchSlide $05
 	note ds7 $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $1
 	env $0 $01
-	cmdf8 $02
+	pitchSlide $02
 	note ds7 $01
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	cmdff

--- a/audio/common/sfx/closeMenu.s
+++ b/audio/common/sfx/closeMenu.s
@@ -4,7 +4,7 @@ sndCloseMenuChannel2:
 	duty $02
 	vol $d
 	env $1 $00
-	cmdf8 $d3
+	pitchSlide $d3
 	note g4  $09
 	cmdff
 
@@ -12,6 +12,6 @@ sndCloseMenuChannel3:
 	duty $01
 	vol $d
 	env $1 $00
-	cmdf8 $e0
+	pitchSlide $e0
 	note g4  $09
 	cmdff

--- a/audio/common/sfx/damageEnemy.s
+++ b/audio/common/sfx/damageEnemy.s
@@ -3,12 +3,12 @@ sndDamageEnemyStart:
 sndDamageEnemyChannel2:
 	duty $00
 	vol $d
-	cmdf8 $81
+	pitchSlide $81
 	note f4  $04
-	cmdf8 $00
+	pitchSlide $00
 	vol $c
 	note g2  $02
 	vol $e
-	cmdf8 $7f
+	pitchSlide $7f
 	note g2  $07
 	cmdff

--- a/audio/common/sfx/damageLink.s
+++ b/audio/common/sfx/damageLink.s
@@ -4,8 +4,8 @@ sndDamageLinkChannel5:
 	cmdfd $fd
 	duty $2d
 	note f2  $01
-	cmdf8 $e7
+	pitchSlide $e7
 	note c5  $03
-	cmdf8 $00
+	pitchSlide $00
 	cmdfd $00
 	cmdff

--- a/audio/common/sfx/damageLink.s
+++ b/audio/common/sfx/damageLink.s
@@ -1,11 +1,11 @@
 sndDamageLinkStart:
 
 sndDamageLinkChannel5:
-	cmdfd $fd
+	pitchOffset -$03
 	duty $2d
 	note f2  $01
 	pitchSlide $e7
 	note c5  $03
 	pitchSlide $00
-	cmdfd $00
+	pitchOffset $00
 	cmdff

--- a/audio/common/sfx/dekuScrub.s
+++ b/audio/common/sfx/dekuScrub.s
@@ -4,13 +4,13 @@ sndDekuScrubChannel2:
 	duty $00
 	vol $d
 	env $1 $00
-	cmdf8 $f1
+	pitchSlide $f1
 	note f6  $05
-	cmdf8 $00
+	pitchSlide $00
 	rest $02
 	vol $e
 	env $1 $00
-	cmdf8 $f1
+	pitchSlide $f1
 	note f6  $05
-	cmdf8 $00
+	pitchSlide $00
 	cmdff

--- a/audio/common/sfx/dimitri.s
+++ b/audio/common/sfx/dimitri.s
@@ -3,10 +3,10 @@ sndDimitriStart:
 sndDimitriChannel5:
 	duty $0b
 	note c3  $02
-	cmdf8 $1e
+	pitchSlide $1e
 	note c3  $05
 	rest $05
 	note c3  $02
-	cmdf8 $1e
+	pitchSlide $1e
 	note c3  $08
 	cmdff

--- a/audio/common/sfx/doorClose.s
+++ b/audio/common/sfx/doorClose.s
@@ -6,9 +6,9 @@ sndDoorCloseChannel2:
 	rest $02
 	vol $6
 	note c4  $01
-	cmdf8 $0f
+	pitchSlide $0f
 	note c4  $05
-	cmdf8 $00
+	pitchSlide $00
 	cmdff
 
 sndDoorCloseChannel7:

--- a/audio/common/sfx/dropEssence.s
+++ b/audio/common/sfx/dropEssence.s
@@ -3,7 +3,7 @@ sndDropEssenceStart:
 sndDropEssenceChannel2:
 	duty $00
 	vol $d
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $01
 	note c7  $0f
 	vol $6

--- a/audio/common/sfx/enemyJump.s
+++ b/audio/common/sfx/enemyJump.s
@@ -4,6 +4,6 @@ sndEnemyJumpChannel2:
 	duty $02
 	vol $b
 	env $0 $02
-	cmdf8 $0f
+	pitchSlide $0f
 	note c4  $13
 	cmdff

--- a/audio/common/sfx/energyThing.s
+++ b/audio/common/sfx/energyThing.s
@@ -19,7 +19,7 @@ sndEnergyThingChannel2:
 	note g7  $01
 	note as7 $01
 	vol $2
-	cmdf8 $01
+	pitchSlide $01
 	note e7  $01
 	note g7  $01
 	note as7 $01
@@ -35,9 +35,9 @@ sndEnergyThingChannel2:
 	note e7  $01
 	note g7  $01
 	note as7 $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $3
-	cmdf8 $03
+	pitchSlide $03
 	note e7  $01
 	note g7  $01
 	note as7 $01
@@ -53,9 +53,9 @@ sndEnergyThingChannel2:
 	note f7  $01
 	note g7  $01
 	note as7 $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $4
-	cmdf8 $05
+	pitchSlide $05
 	note f7  $01
 	note gs7 $01
 	note as7 $01
@@ -71,9 +71,9 @@ sndEnergyThingChannel2:
 	note f7  $01
 	note gs7 $01
 	note as7 $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $6
-	cmdf8 $07
+	pitchSlide $07
 	note f7  $01
 	note gs7 $01
 	note b7  $01
@@ -89,9 +89,9 @@ sndEnergyThingChannel2:
 	note f7  $01
 	note gs7 $01
 	note b7  $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $8
-	cmdf8 $09
+	pitchSlide $09
 	note fs7 $01
 	note gs7 $01
 	note b7  $01
@@ -107,9 +107,9 @@ sndEnergyThingChannel2:
 	note fs7 $01
 	note gs7 $01
 	note b7  $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $9
-	cmdf8 $0b
+	pitchSlide $0b
 	note fs7 $01
 	note a7  $01
 	note b7  $01
@@ -125,9 +125,9 @@ sndEnergyThingChannel2:
 	note fs7 $01
 	note a7  $01
 	note b7  $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $a
-	cmdf8 $0d
+	pitchSlide $0d
 	note fs7 $01
 	note a7  $01
 	note c8  $01
@@ -143,9 +143,9 @@ sndEnergyThingChannel2:
 	note fs7 $01
 	note a7  $01
 	note c8  $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $b
-	cmdf8 $0e
+	pitchSlide $0e
 	note g7  $01
 	note a7  $01
 	note c8  $01
@@ -161,9 +161,9 @@ sndEnergyThingChannel2:
 	note g7  $01
 	note a7  $01
 	note c8  $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $c
-	cmdf8 $0f
+	pitchSlide $0f
 	note g7  $01
 	note as7 $01
 	note c8  $01
@@ -179,9 +179,9 @@ sndEnergyThingChannel2:
 	note g7  $01
 	note as7 $01
 	note c8  $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $d
-	cmdf8 $10
+	pitchSlide $10
 	note g7  $01
 	note as7 $01
 	note cs8 $01
@@ -197,7 +197,7 @@ sndEnergyThingChannel2:
 	note g7  $01
 	note b7  $01
 	note cs8 $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $b
 	note g7  $01
 	note b7  $01

--- a/audio/common/sfx/fallInHole.s
+++ b/audio/common/sfx/fallInHole.s
@@ -3,10 +3,10 @@ sndFallInHoleStart:
 sndFallInHoleChannel2:
 	duty $02
 	vol $9
-	cmdf8 $f6
+	pitchSlide $f6
 	note a4  $14
-	cmdf8 $00
+	pitchSlide $00
 	vol $2
-	cmdf8 $f4
+	pitchSlide $f4
 	note a4  $14
 	cmdff

--- a/audio/common/sfx/gohmaSpawnGel.s
+++ b/audio/common/sfx/gohmaSpawnGel.s
@@ -3,10 +3,10 @@ sndGohmaSpawnGelStart:
 sndGohmaSpawnGelChannel2:
 	duty $00
 	vol $b
-	cmdf8 $05
+	pitchSlide $05
 	note b6  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $4
-	cmdf8 $05
+	pitchSlide $05
 	note b6  $0a
 	cmdff

--- a/audio/common/sfx/goron.s
+++ b/audio/common/sfx/goron.s
@@ -3,11 +3,11 @@ sndGoronStart:
 sndGoronChannel2:
 	duty $00
 	vol $d
-	cmdf8 $c4
+	pitchSlide $c4
 	note a2  $0a
-	cmdf8 $00
+	pitchSlide $00
 	vol $e
-	cmdf8 $37
+	pitchSlide $37
 	note f2  $0f
-	cmdf8 $00
+	pitchSlide $00
 	cmdff

--- a/audio/common/sfx/jump.s
+++ b/audio/common/sfx/jump.s
@@ -4,6 +4,6 @@ sndJumpChannel2:
 	duty $02
 	vol $c
 	env $0 $02
-	cmdf8 $10
+	pitchSlide $10
 	note d4  $14
 	cmdff

--- a/audio/common/sfx/linkSwim.s
+++ b/audio/common/sfx/linkSwim.s
@@ -4,17 +4,17 @@ sndLinkSwimChannel2:
 	duty $02
 	env $2 $00
 	vol $9
-	cmdf8 $16
+	pitchSlide $16
 	note fs3 $0f
-	cmdf8 $00
+	pitchSlide $00
 	rest $02
 	env $1 $00
 	vol $1
-	cmdf8 $0f
+	pitchSlide $0f
 	note gs3 $0a
 	env $0 $00
 	vol $4
-	cmdf8 $16
+	pitchSlide $16
 	note b3  $05
 	cmdff
 

--- a/audio/common/sfx/makuTreePast.s
+++ b/audio/common/sfx/makuTreePast.s
@@ -5,22 +5,22 @@ sndMakuTreePastChannel2:
 	vol $5
 	env $1 $00
 	vibrato $00
-	cmdf8 $04
+	pitchSlide $04
 	note g6  $05
 	vol $3
 	env $0 $07
 	vibrato $00
-	cmdf8 $ff
+	pitchSlide $ff
 	note c7  $37
 	cmdff
 
 sndMakuTreePastChannel5:
 	duty $08
 	vibrato $00
-	cmdf8 $04
+	pitchSlide $04
 	note g6  $05
 	vibrato $00
-	cmdf8 $ff
+	pitchSlide $ff
 	note c7  $28
 	cmdff
 

--- a/audio/common/sfx/moosh.s
+++ b/audio/common/sfx/moosh.s
@@ -1,15 +1,15 @@
 sndMooshStart:
 sndMooshChannel5:
 	duty $0a
-	cmdf8 $1e
+	pitchSlide $1e
 	note c3  $05
 	rest $02
-	cmdf8 $2e
+	pitchSlide $2e
 	note c3  $08
 	rest $08
-	cmdf8 $e2
+	pitchSlide $e2
 	note gs3 $08
 	rest $06
-	cmdf8 $d8
+	pitchSlide $d8
 	note gs3 $08
 	cmdff

--- a/audio/common/sfx/openMenu.s
+++ b/audio/common/sfx/openMenu.s
@@ -4,7 +4,7 @@ sndOpenMenuChannel2:
 	duty $01
 	vol $f
 	env $3 $00
-	cmdf8 $23
+	pitchSlide $23
 	note c3  $16
 	cmdff
 
@@ -12,6 +12,6 @@ sndOpenMenuChannel3:
 	duty $02
 	vol $f
 	env $3 $00
-	cmdf8 $2c
+	pitchSlide $2c
 	note c2  $16
 	cmdff

--- a/audio/common/sfx/pickUp.s
+++ b/audio/common/sfx/pickUp.s
@@ -3,9 +3,9 @@ sndPickupStart:
 sndPickupChannel2:
 	cmdf0 $80
 	vol $9
-	cmdf8 $1e
+	pitchSlide $1e
 	.db $03 $2c $0d
-	cmdf8 $00
+	pitchSlide $00
 	.db $05 $12 $01
 	.db $05 $8c $01
 	.db $05 $ef $01

--- a/audio/common/sfx/pirateBell.s
+++ b/audio/common/sfx/pirateBell.s
@@ -3,9 +3,9 @@ sndPirateBellStart:
 sndPirateBellChannel2:
 	duty $00
 	vol $c
-	cmdf8 $20
+	pitchSlide $20
 	note a4  $01
-	cmdf8 $00
+	pitchSlide $00
 	vol $7
 	note c5  $01
 	note ds5 $01

--- a/audio/common/sfx/poof.s
+++ b/audio/common/sfx/poof.s
@@ -3,26 +3,26 @@ sndPoofStart:
 sndPoofChannel2:
 	vol $d
 	cmdf0 $80
-	cmdf8 $61
+	pitchSlide $61
 	.db $05 $39 $03
-	cmdf8 $9f
+	pitchSlide $9f
 	.db $06 $3f $03
-	cmdf8 $61
+	pitchSlide $61
 	.db $05 $39 $03
-	cmdf8 $9f
+	pitchSlide $9f
 	.db $06 $3f $03
-	cmdf8 $61
+	pitchSlide $61
 	.db $05 $39 $03
 	vol $8
-	cmdf8 $9f
+	pitchSlide $9f
 	.db $06 $3f $03
 	vol $6
-	cmdf8 $61
+	pitchSlide $61
 	.db $05 $39 $03
 	vol $4
-	cmdf8 $9f
+	pitchSlide $9f
 	.db $06 $3f $03
 	vol $2
-	cmdf8 $66
+	pitchSlide $66
 	.db $05 $39 $03
 	cmdff

--- a/audio/common/sfx/ricky.s
+++ b/audio/common/sfx/ricky.s
@@ -2,18 +2,18 @@ sndRickyStart:
 
 sndRickyChannel5:
 	duty $03
-	cmdf8 $0c
+	pitchSlide $0c
 	note g5  $05
 	vol $0
 	rest $08
-	cmdf8 $fe
+	pitchSlide $fe
 	note d6  $05
-	cmdf8 $00
+	pitchSlide $00
 	note g5  $01
-	cmdf8 $0c
+	pitchSlide $0c
 	note g5  $05
 	vol $0
 	rest $0a
-	cmdf8 $fe
+	pitchSlide $fe
 	note d6  $0f
 	cmdff

--- a/audio/common/sfx/scentSeed.s
+++ b/audio/common/sfx/scentSeed.s
@@ -3,40 +3,40 @@ sndScentSeedStart:
 sndScentSeedChannel2:
 	duty $02
 	vol $f
-	cmdf8 $ce
+	pitchSlide $ce
 	note a2  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $e
-	cmdf8 $50
+	pitchSlide $50
 	note f2  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $a
-	cmdf8 $ce
+	pitchSlide $ce
 	note a2  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $8
-	cmdf8 $50
+	pitchSlide $50
 	note f2  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $7
-	cmdf8 $ce
+	pitchSlide $ce
 	note a2  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $6
-	cmdf8 $50
+	pitchSlide $50
 	note f2  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $5
-	cmdf8 $ce
+	pitchSlide $ce
 	note a2  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $4
-	cmdf8 $50
+	pitchSlide $50
 	note f2  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $3
 	env $0 $03
-	cmdf8 $ce
+	pitchSlide $ce
 	note a2  $06
-	cmdf8 $00
+	pitchSlide $00
 	cmdff

--- a/audio/common/sfx/seedShooter.s
+++ b/audio/common/sfx/seedShooter.s
@@ -3,9 +3,9 @@ sndSeedShooterStart:
 sndSeedShooterChannel2:
 	duty $02
 	vol $c
-	cmdf8 $28
+	pitchSlide $28
 	note ds5 $02
-	cmdf8 $00
+	pitchSlide $00
 	note ds5 $01
 	duty $02
 	vol $6

--- a/audio/common/sfx/shield.s
+++ b/audio/common/sfx/shield.s
@@ -3,15 +3,15 @@ sndShieldStart:
 sndShieldChannel2:
 	duty $00
 	vol $0
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $00
 	note c7  $01
 	vol $f
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $01
 	note c2  $01
 	vol $e
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $01
 	note c7  $01
 	vol $0

--- a/audio/common/sfx/splash.s
+++ b/audio/common/sfx/splash.s
@@ -4,6 +4,6 @@ sndSplashChannel2:
 	duty $02
 	env $1 $00
 	vol $3
-	cmdf8 $30
+	pitchSlide $30
 	note fs4 $06
 	cmdff

--- a/audio/common/sfx/throw.s
+++ b/audio/common/sfx/throw.s
@@ -4,11 +4,11 @@ sndThrowChannel2:
 	duty $02
 	vol $d
 	env $1 $00
-	cmdf8 $f4
+	pitchSlide $f4
 	note d6  $0a
-	cmdf8 $00
+	pitchSlide $00
 	vol $8
 	env $0 $01
-	cmdf8 $e0
+	pitchSlide $e0
 	note c5  $08
 	cmdff

--- a/audio/common/sfx/unknown3.s
+++ b/audio/common/sfx/unknown3.s
@@ -4,23 +4,23 @@ sndUnknown3Channel2:
 	duty $01
 	vibrato $0b
 	vol $c
-	cmdf8 $36
+	pitchSlide $36
 	note c3  $08
-	cmdf8 $00
+	pitchSlide $00
 	vol $9
 	note gs5 $01
 	note b4  $01
 	vol $9
-	cmdf8 $18
+	pitchSlide $18
 	note g3  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $7
 	note gs5 $01
 	note b4  $01
 	vol $7
-	cmdf8 $18
+	pitchSlide $18
 	note g3  $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $7
 	note gs5 $01
 	note b4  $01

--- a/audio/common/sfx/veranProjectile.s
+++ b/audio/common/sfx/veranProjectile.s
@@ -7,54 +7,54 @@ sndVeranProjectileChannel2:
 	vol $d
 	.db $07 $80 $01
 	vol $9
-	cmdf8 $fc
+	pitchSlide $fc
 	.db $07 $80 $05
-	cmdf8 $00
+	pitchSlide $00
 	.db $07 $68 $01
 	.db $07 $58 $01
 	.db $07 $46 $01
 	vol $b
 	.db $07 $80 $01
 	vol $9
-	cmdf8 $fc
+	pitchSlide $fc
 	.db $07 $80 $05
-	cmdf8 $00
+	pitchSlide $00
 	.db $07 $68 $01
 	.db $07 $58 $01
 	.db $07 $46 $01
 	vol $a
 	.db $07 $80 $01
 	vol $8
-	cmdf8 $fc
+	pitchSlide $fc
 	.db $07 $80 $05
-	cmdf8 $00
+	pitchSlide $00
 	.db $07 $68 $01
 	.db $07 $58 $01
 	.db $07 $46 $01
 	vol $9
 	.db $07 $80 $01
 	vol $7
-	cmdf8 $fc
+	pitchSlide $fc
 	.db $07 $80 $05
-	cmdf8 $00
+	pitchSlide $00
 	.db $07 $68 $01
 	.db $07 $58 $01
 	.db $07 $46 $01
 	vol $8
 	.db $07 $80 $01
 	vol $6
-	cmdf8 $fc
+	pitchSlide $fc
 	.db $07 $80 $05
-	cmdf8 $00
+	pitchSlide $00
 	.db $07 $68 $01
 	.db $07 $58 $01
 	.db $07 $46 $01
 	vol $5
 	.db $07 $80 $01
 	vol $3
-	cmdf8 $fc
+	pitchSlide $fc
 	.db $07 $80 $05
-	cmdf8 $00
+	pitchSlide $00
 	.db $07 $68 $01
 	.db $07 $58 $01
 	.db $07 $46 $01
@@ -62,6 +62,6 @@ sndVeranProjectileChannel2:
 	.db $07 $80 $01
 	env $0 $03
 	vol $1
-	cmdf8 $fc
+	pitchSlide $fc
 	.db $07 $80 $05
 	cmdff

--- a/audio/seasons/sfx/7d.s
+++ b/audio/seasons/sfx/7d.s
@@ -4,11 +4,11 @@ sndUnknown7dChannel2:
 	duty $02
 	vol $f
 	env $2 $00
-	cmdf8 $0b
+	pitchSlide $0b
 	note g2  $18
-	cmdf8 $00
+	pitchSlide $00
 	env $0 $05
-	cmdf8 $f8
+	pitchSlide $f8
 	note b2  $33
-	cmdf8 $00
+	pitchSlide $00
 	cmdff

--- a/audio/seasons/sfx/8e.s
+++ b/audio/seasons/sfx/8e.s
@@ -2,32 +2,32 @@ sndUnknown8eStart:
 sndUnknown8eChannel2:
 	duty $02
 	vol $c
-	cmdf8 $e8
+	pitchSlide $e8
 	note as4 $05
-	cmdf8 $00
+	pitchSlide $00
 	vol $0
 	rest $0c
 	vol $c
 	env $0 $01
-	cmdf8 $e6
+	pitchSlide $e6
 	note fs4 $08
-	cmdf8 $00
+	pitchSlide $00
 	vol $c
 	env $0 $01
-	cmdf8 $ee
+	pitchSlide $ee
 	note fs4 $06
-	cmdf8 $00
+	pitchSlide $00
 	vol $0
 	rest $03
 	vol $d
 	env $0 $01
-	cmdf8 $de
+	pitchSlide $de
 	note b3  $0f
-	cmdf8 $00
+	pitchSlide $00
 	vol $0
 	rest $0b
 	vol $d
 	env $0 $01
-	cmdf8 $de
+	pitchSlide $de
 	note b3  $0f
 	cmdff

--- a/audio/seasons/sfx/creepyLaugh.s
+++ b/audio/seasons/sfx/creepyLaugh.s
@@ -4,29 +4,29 @@ sndCreepyLaughChannel2:
 	duty $00
 	env $0 $01
 	vol $b
-	cmdf8 $09
+	pitchSlide $09
 	note d6  $07
-	cmdf8 $00
+	pitchSlide $00
 	vol $0
 	rest $04
 	vol $9
-	cmdf8 $08
+	pitchSlide $08
 	note d6  $08
-	cmdf8 $00
+	pitchSlide $00
 	vol $0
 	rest $03
 	vol $7
-	cmdf8 $08
+	pitchSlide $08
 	note cs6 $08
-	cmdf8 $00
+	pitchSlide $00
 	vol $0
 	rest $02
 	vol $5
-	cmdf8 $09
+	pitchSlide $09
 	note c6  $0a
-	cmdf8 $00
+	pitchSlide $00
 	vol $4
-	cmdf8 $0a
+	pitchSlide $0a
 	note as5 $0a
-	cmdf8 $00
+	pitchSlide $00
 	cmdff

--- a/audio/seasons/sfx/d1.s
+++ b/audio/seasons/sfx/d1.s
@@ -3,14 +3,14 @@ sndUnknownd1Start:
 sndUnknownd1Channel2:
 	duty $00
 	vol $9
-	cmdf8 $7f
+	pitchSlide $7f
 	note d3  $03
-	cmdf8 $00
-	cmdf8 $81
+	pitchSlide $00
+	pitchSlide $81
 	note a3  $03
-	cmdf8 $00
+	pitchSlide $00
 	vol $f
-	cmdf8 $ef
+	pitchSlide $ef
 	note a2  $32
 	cmdff
 sndUnknownd1Channel7:

--- a/audio/seasons/sfx/danceMove.s
+++ b/audio/seasons/sfx/danceMove.s
@@ -2,16 +2,16 @@ sndDanceMoveStart:
 sndDanceMoveChannel2:
 	duty $02
 	vol $f
-	cmdf8 $ee
+	pitchSlide $ee
 	note e3  $02
-	cmdf8 $00
+	pitchSlide $00
 	vol $f
 	note a2  $01
 	vol $f
 	note a2  $04
 	env $0 $01
 	note as2 $0c
-	cmdf8 $f6
+	pitchSlide $f6
 	cmdff
 sndDanceMoveChannel7:
 	cmdf0 $f1

--- a/audio/seasons/sfx/dodongoEat.s
+++ b/audio/seasons/sfx/dodongoEat.s
@@ -1,6 +1,6 @@
 sndDodongoEatStart:
 sndDodongoEatChannel2:
 	vol $e
-	cmdf8 $10
+	pitchSlide $10
 	note f2  $11
 	cmdff

--- a/audio/seasons/sfx/makuTreeSnore.s
+++ b/audio/seasons/sfx/makuTreeSnore.s
@@ -3,13 +3,13 @@ sndMakuTreeSnoreChannel2:
 	duty $01
 	env $2 $04
 	vol $7
-	cmdf8 $09
+	pitchSlide $09
 	cmdfd $fc
 	note b3  $41
 	vol $0
 	rest $11
 	env $3 $03
 	vol $4
-	cmdf8 $f8
+	pitchSlide $f8
 	note e5  $37
 	cmdff

--- a/audio/seasons/sfx/makuTreeSnore.s
+++ b/audio/seasons/sfx/makuTreeSnore.s
@@ -4,7 +4,7 @@ sndMakuTreeSnoreChannel2:
 	env $2 $04
 	vol $7
 	pitchSlide $09
-	cmdfd $fc
+	pitchOffset -$04
 	note b3  $41
 	vol $0
 	rest $11

--- a/code/audio.s
+++ b/code/audio.s
@@ -94,7 +94,7 @@ updateMusicVolume:
 	push de
 	push hl
 	push af
-	call silenceSquareMusicChannels
+	call silencePulseMusicChannels
 
 	pop af
 	ld (wMusicVolume),a
@@ -114,8 +114,8 @@ updateMusicVolume:
 
 ;;
 ; Silences channels 0 and 1 if enabled
-silenceSquareMusicChannels:
-	; Update square 1's volume
+silencePulseMusicChannels:
+	; Update pulse 1's volume
 	ld a,$00
 	ld (wSoundChannel),a
 	ld hl,wChannelsEnabled
@@ -128,7 +128,7 @@ silenceSquareMusicChannels:
 	jr z,+
 	call silencePlayedSound
 +
-	; Update square 2's volume
+	; Update pulse 2's volume
 	ld a,$01
 	ld (wSoundChannel),a
 	ld hl,wChannelsEnabled
@@ -171,7 +171,7 @@ silenceAllChannels:
 ; Disable all sound effect channels
 ;
 stopSfx:
-	; Square 1
+	; Pulse 1
 	ld a,$02
 	ld (wSoundChannel),a
 	ld hl,wChannelsEnabled
@@ -184,7 +184,7 @@ stopSfx:
 	jr z,+
 	call channelCmdff
 +
-	; Square 2
+	; Pulse 2
 	ld a,$03
 	ld (wSoundChannel),a
 	ld hl,wChannelsEnabled
@@ -545,7 +545,7 @@ updatePlayedFrequency:
 	jr nc,@wave
 
 	cp $02
-	jr nc,@square
+	jr nc,@pulse
 
 	; For music, check if channel is free
 	inc a
@@ -556,10 +556,10 @@ updatePlayedFrequency:
 	add hl,de
 	ld a,(hl)
 	cp $00
-	jr z,@square
+	jr z,@pulse
 	ret
 
-@square:
+@pulse:
 	ld a,(wSoundChannel)
 	and $01
 	ld b,a
@@ -742,7 +742,8 @@ channelCmdf9:
 	jp doNextChannelCommand
 
 ;;
-; Sets sweep to the argument value, does nothing for noise channels
+; Continuous pitch slide
+; Signed argument value that gets added to the channel's frequency every frame, does nothing for noise channels
 channelCmdf8:
 	ld a,(wSoundChannel)
 	scf
@@ -786,7 +787,7 @@ channelCmdfd:
 
 ;;
 ; Sets the channel envelopes to the lower 3 bits of the command value (note start) and the argument value (note end)
-; Should not be used with wave or noise channels or else wChannelEnvelopes2 and wChannelsEnabled get messed up for square channels
+; Should not be used with wave or noise channels or else wChannelEnvelopes2 and wChannelsEnabled get messed up for pulse channels
 cmde0Toef:
 	and $07
 	ld hl,wChannelEnvelopes
@@ -912,7 +913,7 @@ cmdVolume:
 	jp doNextChannelCommand
 
 ;;
-; For square channels, sets wChannelDutyCycles to the argument value shifted 6 bits to the left
+; For pulse channels, sets wChannelDutyCycles to the argument value shifted 6 bits to the left
 ; For wave channels, sets wChannelDutyCycles to the argument value and updates the waveform based on that index
 ; Should not be used with noise channels or else wChannelEnvelopeStates gets messed up for channel 0 or 1
 channelCmdf6:
@@ -1023,7 +1024,7 @@ standardSoundCmd:
 	ld c,$01
 	or c
 	ld (wSoundCmdEnvelope),a
-	call updateSquareChannelVolume
+	call updatePulseChannelVolume
 	call updateSoundFrequencyAndPlay
 @cmd61:
 	jp setChannelWaitCounter
@@ -1143,7 +1144,7 @@ setSoundFrequency:
 	ret
 
 ;;
-; Handles envelopes for square channels, and redirects channel 4 to updateChannel4Volume
+; Handles envelopes for pulse channels, and redirects channel 4 to updateChannel4Volume
 handleEnvelopes:
 	ld a,(wSoundChannel)
 	cp $04
@@ -1203,7 +1204,7 @@ handleEnvelopes:
 	add hl,de
 	pop af
 	ld (hl),a
-	jp updateSquareChannelVolume
+	jp updatePulseChannelVolume
 
 @waitForNoteStartEnvelope:
 	ld hl,wChannelEnvelopeWaitCounters
@@ -1267,10 +1268,10 @@ handleEnvelopes:
 	ld a,(wSoundCmdEnvelope)
 	or c
 	ld (wSoundCmdEnvelope),a
-	jp updateSquareChannelVolume
+	jp updatePulseChannelVolume
 
 ;;
-updateSquareChannelVolume:
+updatePulseChannelVolume:
 	ld a,(wSoundChannel)
 	cp $02
 	jr nc,++
@@ -1346,7 +1347,7 @@ updateChannel4Volume:
 	ret
 
 ;;
-; Intended for use with square and noise channels, but not used by channel 7
+; Intended for use with pulse and noise channels, but not used by channel 7
 ; Channel 6 uses @affectedByMusicVolume as entry point
 ; @param[out]	a	Final volume of channel wSoundChannel after possible modification with wMusicVolume ($0-$f)
 getChannelVolume:
@@ -1635,16 +1636,16 @@ silencePlayedSound:
 	jp hl
 
 @table:
-	.dw @musicSquareChannel
-	.dw @musicSquareChannel
-	.dw @sfxSquareChannel
-	.dw @sfxSquareChannel
+	.dw @musicPulseChannel
+	.dw @musicPulseChannel
+	.dw @sfxPulseChannel
+	.dw @sfxPulseChannel
 	.dw @musicWaveChannel
 	.dw @sfxWaveChannel
 	.dw @noiseChannel
 	.dw @noiseChannel
 
-@musicSquareChannel:
+@musicPulseChannel:
 	; Only update if the corresponding sfx channel is not enabled
 	ld a,(wSoundChannel)
 	inc a
@@ -1658,7 +1659,7 @@ silencePlayedSound:
 	jr z,+
 	ret
 
-@sfxSquareChannel:
+@sfxPulseChannel:
 	; Sfx always updates (but it still does this pointless check of the corresponding
 	; music channel)
 	ld a,(wSoundChannel)
@@ -1687,7 +1688,7 @@ silencePlayedSound:
 	; Set volume to $0 and trigger channel
 	ld a,$08
 	ld (wSoundCmdEnvelope),a
-	call updateSquareChannelVolume
+	call updatePulseChannelVolume
 	jp updatePlayedFrequency
 
 @musicWaveChannel:
@@ -2127,13 +2128,13 @@ playSound:
 	ld (hl),a
 	ld a,(wSoundTmp)
 	cp $00
-	jr z,@squareChannel
+	jr z,@pulseChannel
 	cp $01
-	jr z,@squareChannel
+	jr z,@pulseChannel
 	cp $02
-	jr z,@squareChannel
+	jr z,@pulseChannel
 	cp $03
-	jr z,@squareChannel
+	jr z,@pulseChannel
 	cp $04
 	jr z,@waveChannel
 	cp $05
@@ -2164,7 +2165,7 @@ playSound:
 	ld (hl),a
 	jr ++
 
-@squareChannel:
+@pulseChannel:
 	ld a,(wSoundTmp)
 	ld e,a
 

--- a/include/musicMacros.s
+++ b/include/musicMacros.s
@@ -276,253 +276,75 @@
 	.redefine R3 Y5+Y6
 .endm
 
-; Subdivides Q (see "tempo") into \1 equal parts (X1-X\1), for note lengths that don't fit the
-; eighth/twelfth-based groupings "tempo" already provides (e.g. triplets, quintuplets).
-.macro noteLen
-	.redefine X1 (Q - (Q # \1))/\1
-	.redefine X2 (Q * 2 - ((Q * 2) # \1))/\1 - X1
-	.redefine X3 (Q * 3 - ((Q * 3) # \1))/\1 - (X1+X2)
-	.redefine X4 (Q * 4 - ((Q * 4) # \1))/\1 - (X1+X2+X3)
-	.redefine X5 (Q * 5 - ((Q * 5) # \1))/\1 - (X1+X2+X3+X4)
-	.redefine X6 (Q * 6 - ((Q * 6) # \1))/\1 - (X1+X2+X3+X4+X5)
-	.redefine X7 (Q * 7 - ((Q * 7) # \1))/\1 - (X1+X2+X3+X4+X5+X6)
-	.redefine X8 (Q * 8 - ((Q * 8) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7)
-	.redefine X9 (Q * 9 - ((Q * 9) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7+X8)
-	.redefine X10 (Q * 10 - ((Q * 10) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7+X8+X9)
-	.redefine X11 (Q * 11 - ((Q * 11) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7+X8+X9+X10)
-	.redefine X12 (Q * 12 - ((Q * 12) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7+X8+X9+X10+X11)
-.endm
+; Picks out the pair of "tempo" length constants that split a given note-length symbol (\1: one
+; of Q, E1, E2) in half, rebinding them to HF1/HF2 (halves), TR1-3/QR1-4/SX1-6 (thirds/quarters/
+; sixths of \1). Lets a beat-style macro divide a note of length \1 into a shorter attack and a
+; release without hardcoding which "tempo" constants apply at each note-length tier.
+.macro m_splitLength
+	.if \1 == Q
+		.redefine HF1 E1
+		.redefine HF2 E2
 
-; A variation of the "beat" macro that includes a common functionality of the volume adjustments
-; in the music: each note plays for HI_VOL first, then drops to LO_VOL for the rest of its length
-; (ratio set by caller-defined LO_VOL_RATIO, e.g. 1/4). Optional caller-defined settings:
-;   NO_FIRST_VOL: skip the initial HI_VOL volume/duty command (e.g. if already set)
-;   CHANNEL: set to 4 to use "duty" instead of "vol" for the volume commands (wave channel)
-;   NOTE_MID_WAIT / NOTE_END_WAIT: carve a rest out of the end of the HI_VOL / LO_VOL portion
-; Following a note/length pair with "r <length>" extends the rest at the end of that note.
-;	vol $6
-;	beat a 1
-;	vol $3
-;	beat a 1
-;
-;	volbeat a 2
-.macro volbeat
-	.ifndef HI_VOL
-		.define HI_VOL 0
-	.endif
+		.redefine TR1 R1
+		.redefine TR2 R2
+		.redefine TR3 R3
 
-	.ifndef LO_VOL
-		.define LO_VOL 0
-	.endif
+		.redefine QR1 S1
+		.redefine QR2 S2
+		.redefine QR3 S3
+		.redefine QR4 S4
 
-	.ifndef NO_FIRST_VOL
-		.define NO_FIRST_VOL 0
-	.endif
-
-	.ifndef REST
-		.define REST 0
-	.endif
-	.redefine REST 0
-
-	.ifndef CHANNEL
-		.define CHANNEL 0
-	.endif
-	.ifndef NOTE_MID_WAIT
-		.define NOTE_MID_WAIT 0
-	.endif
-
-	.ifndef NOTE_END_WAIT
-		.define NOTE_END_WAIT 0
-	.endif
-
-	.redefine offset 0
-	.rept NARGS
-	.if NARGS >= 1
-		.if \1 == od
-			octaved
-			.redefine offset offset-12
-			.shift
-		.else
-		.if \1 == ou
-			octaveu
-			.redefine offset offset+12
-			.shift
-		.endif
-		.endif
-	.endif
-
-	.if NARGS >= 2
-	.if \1 == r
-		rest \2*BEAT
-		.shift
-		.shift
+		.redefine SX1 Y1
+		.redefine SX2 Y2
+		.redefine SX3 Y3
+		.redefine SX4 Y4
+		.redefine SX5 Y5
+		.redefine SX6 Y6
 	.else
-	.if \1 >= 0
-		; First volume change
-		.if NO_FIRST_VOL == 0
-			.if CHANNEL == 4
-				duty HI_VOL
-			.else
-				vol HI_VOL
-			.endif
-		.endif
+	.if \1 == E1
+		.redefine HF1 S1
+		.redefine HF2 S2
 
-		; First note
-		.db \1+offset
+		.redefine TR1 Y1
+		.redefine TR2 Y2
+		.redefine TR3 Y3
 
-		.redefine LO_LENGTH ((\2*BEAT)-((\2*BEAT)#(1/LO_VOL_RATIO)))*LO_VOL_RATIO
-		.if ((\2*BEAT)#(1/LO_VOL_RATIO)) >= 0.5/LO_VOL_RATIO
-			.redefine LO_LENGTH LO_LENGTH + 1
-		.endif
-		.redefine HI_LENGTH (\2*BEAT)-LO_LENGTH
+		.redefine QR1 T1
+		.redefine QR2 T2
+		.redefine QR3 T3
+		.redefine QR4 T4
 
-		.if NOTE_MID_WAIT != 0
-			.db HI_LENGTH - NOTE_MID_WAIT
-			rest NOTE_MID_WAIT
-		.else
-			.db HI_LENGTH
-		.endif
-
-		; Second volume change
-		.if CHANNEL == 4
-			duty LO_VOL
-		.else
-			vol LO_VOL
-		.endif
-
-		; Second note
-		.db \1+offset
-
-		.if NARGS >= 4
-			.if \3 == r
-				.redefine REST \4*BEAT
-			.endif
-		.endif
-
-		.if NOTE_END_WAIT != 0
-			.db LO_LENGTH - (NOTE_END_WAIT + REST)
-			rest NOTE_END_WAIT + REST
-		.else
-			.db LO_LENGTH
-		.endif
-
-		.if NARGS >= 4
-			.if \3 == r
-				.if NOTE_END_WAIT == 0
-					rest REST
-				.endif
-				.shift
-				.shift
-			.endif
-		.endif
-
-		.shift
-		.shift
-	.endif
-	.endif
-	.endif
-	.endr
-.endm
-
-; Used for alternating two notes with a volume dip on each, e.g. Tarm Ruins' music. Call
-; repeatedly with one note/length pair per call; each call plays the *previous* call's note at
-; LO_VOL for its tail (via TARM_NOTE) before the current note's HI_VOL attack, except the first
-; call which only plays its own note.
-;	vol HI_VOL
-;	beat a 12
-;	rest 12
-;
-;	beat b 12
-;	vol LO_VOL
-;	beat a 12
-;
-;	vol HI_VOL
-;	beat c 12
-;	vol LO_VOL
-;	beat b 12
-;
-;	tarmbeat a 24 b 24 c 24
-.macro tarmbeat
-	.redefine offset 0
-	.rept NARGS
-	.if NARGS >= 1
-		.if \1 == od
-			octaved
-			.redefine offset offset-12
-			.shift
-		.else
-		.if \1 == ou
-			octaveu
-			.redefine offset offset+12
-			.shift
-		.endif
-		.endif
-	.endif
-
-	.if NARGS >= 2
-	.if \1 == r
-		rest \2*BEAT
-		.shift
-		.shift
+		.redefine SX1 W1
+		.redefine SX2 W2
+		.redefine SX3 W3
+		.redefine SX4 W4
+		.redefine SX5 W5
+		.redefine SX6 W6
 	.else
-	.if \1 >= 0
-		.ifndef HI_VOL
-			.define HI_VOL 0
-		.endif
+	.if \1 == E2
+		.redefine HF1 S3
+		.redefine HF2 S4
 
-		.ifndef LO_VOL
-			.define LO_VOL 0
-		.endif
+		.redefine TR1 Y4
+		.redefine TR2 Y5
+		.redefine TR3 Y6
 
-		.ifndef NO_FIRST_VOL
-			.define NO_FIRST_VOL 0
-		.endif
+		.redefine QR1 T5
+		.redefine QR2 T6
+		.redefine QR3 T7
+		.redefine QR4 T8
 
-		.ifndef CHANNEL
-			.define CHANNEL 0
-		.endif
-
-		.ifndef TARM_NOTE
-			.define TARM_NOTE 0
-		.endif
-
-		; First volume change
-		.if NO_FIRST_VOL == 0
-			.if CHANNEL == 4
-				duty HI_VOL
-			.else
-				vol HI_VOL
-			.endif
-		.endif
-		; First note
-		.db \1+offset
-		.db \2*BEAT*(1-LO_VOL_RATIO)
-
-		; Second volume change
-		.if TARM_NOTE != 0
-			.if CHANNEL == 4
-				duty LO_VOL
-			.else
-				vol LO_VOL
-			.endif
-
-			; Second note
-			.db TARM_NOTE
-			.db \2*BEAT*LO_VOL_RATIO
-			.redefine NO_FIRST_VOL 0
-		.else
-			rest \2*BEAT*LO_VOL_RATIO
-			.redefine NO_FIRST_VOL 1
-		.endif
-
-		.redefine TARM_NOTE \1+offset
-
-		.shift
-		.shift
+		.redefine SX1 W7
+		.redefine SX2 W8
+		.redefine SX3 W9
+		.redefine SX4 W10
+		.redefine SX5 W11
+		.redefine SX6 W12
+	.else
+		.fail
 	.endif
 	.endif
 	.endif
-	.endr
 .endm
 
 ; 60: rest, stops playing the previous note and sets wait counter

--- a/include/musicMacros.s
+++ b/include/musicMacros.s
@@ -222,6 +222,309 @@
 	.endr
 .endm
 
+; Sets up note-length constants (T1-T8, W1-W12, and their groupings) for a given tempo, in beats
+; per minute. BEAT is set to 1, so "beat"/"note" length arguments become raw frame counts scaled
+; off Q (frames per beat at this tempo). Ported from a Tarm Ruins-era macro set; not tied to any
+; particular song and safe to call multiple times (e.g. once per tempo change within a song).
+.macro tempo
+	.redefine Q (150*24 - (150*24) # \1) / \1
+
+	.if ((150*24) # \1) >= 0.5*\1
+		.redefine Q Q+1
+	.endif
+
+	.redefine T1 (Q - (Q # 8))/8
+	.redefine T2 (Q * 2 - ((Q * 2) # 8))/8 - T1
+	.redefine T3 (Q * 3 - ((Q * 3) # 8))/8 - (T1+T2)
+	.redefine T4 (Q * 4 - ((Q * 4) # 8))/8 - (T1+T2+T3)
+	.redefine T5 (Q * 5 - ((Q * 5) # 8))/8 - (T1+T2+T3+T4)
+	.redefine T6 (Q * 6 - ((Q * 6) # 8))/8 - (T1+T2+T3+T4+T5)
+	.redefine T7 (Q * 7 - ((Q * 7) # 8))/8 - (T1+T2+T3+T4+T5+T6)
+	.redefine T8 (Q * 8 - ((Q * 8) # 8))/8 - (T1+T2+T3+T4+T5+T6+T7)
+
+	.redefine S1 T1+T2
+	.redefine S2 T3+T4
+	.redefine S3 T5+T6
+	.redefine S4 T7+T8
+	.redefine E1 S1+S2
+	.redefine E2 S3+S4
+	.redefine HF Q*2
+	.redefine W Q*4
+	.redefine BEAT 1
+
+	.redefine W1 (Q - (Q # 12))/12
+	.redefine W2 (Q * 2 - ((Q * 2) # 12))/12 - W1
+	.redefine W3 (Q * 3 - ((Q * 3) # 12))/12 - (W1+W2)
+	.redefine W4 (Q * 4 - ((Q * 4) # 12))/12 - (W1+W2+W3)
+	.redefine W5 (Q * 5 - ((Q * 5) # 12))/12 - (W1+W2+W3+W4)
+	.redefine W6 (Q * 6 - ((Q * 6) # 12))/12 - (W1+W2+W3+W4+W5)
+	.redefine W7 (Q * 7 - ((Q * 7) # 12))/12 - (W1+W2+W3+W4+W5+W6)
+	.redefine W8 (Q * 8 - ((Q * 8) # 12))/12 - (W1+W2+W3+W4+W5+W6+W7)
+	.redefine W9 (Q * 9 - ((Q * 9) # 12))/12 - (W1+W2+W3+W4+W5+W6+W7+W8)
+	.redefine W10 (Q * 10 - ((Q * 10) # 12))/12 - (W1+W2+W3+W4+W5+W6+W7+W8+W9)
+	.redefine W11 (Q * 11 - ((Q * 11) # 12))/12 - (W1+W2+W3+W4+W5+W6+W7+W8+W9+W10)
+	.redefine W12 (Q * 12 - ((Q * 12) # 12))/12 - (W1+W2+W3+W4+W5+W6+W7+W8+W9+W10+W11)
+
+	.redefine Y1 W1+W2
+	.redefine Y2 W3+W4
+	.redefine Y3 W5+W6
+	.redefine Y4 W7+W8
+	.redefine Y5 W9+W10
+	.redefine Y6 W11+W12
+	.redefine R1 Y1+Y2
+	.redefine R2 Y3+Y4
+	.redefine R3 Y5+Y6
+.endm
+
+; Subdivides Q (see "tempo") into \1 equal parts (X1-X\1), for note lengths that don't fit the
+; eighth/twelfth-based groupings "tempo" already provides (e.g. triplets, quintuplets).
+.macro noteLen
+	.redefine X1 (Q - (Q # \1))/\1
+	.redefine X2 (Q * 2 - ((Q * 2) # \1))/\1 - X1
+	.redefine X3 (Q * 3 - ((Q * 3) # \1))/\1 - (X1+X2)
+	.redefine X4 (Q * 4 - ((Q * 4) # \1))/\1 - (X1+X2+X3)
+	.redefine X5 (Q * 5 - ((Q * 5) # \1))/\1 - (X1+X2+X3+X4)
+	.redefine X6 (Q * 6 - ((Q * 6) # \1))/\1 - (X1+X2+X3+X4+X5)
+	.redefine X7 (Q * 7 - ((Q * 7) # \1))/\1 - (X1+X2+X3+X4+X5+X6)
+	.redefine X8 (Q * 8 - ((Q * 8) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7)
+	.redefine X9 (Q * 9 - ((Q * 9) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7+X8)
+	.redefine X10 (Q * 10 - ((Q * 10) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7+X8+X9)
+	.redefine X11 (Q * 11 - ((Q * 11) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7+X8+X9+X10)
+	.redefine X12 (Q * 12 - ((Q * 12) # \1))/\1 - (X1+X2+X3+X4+X5+X6+X7+X8+X9+X10+X11)
+.endm
+
+; A variation of the "beat" macro that includes a common functionality of the volume adjustments
+; in the music: each note plays for HI_VOL first, then drops to LO_VOL for the rest of its length
+; (ratio set by caller-defined LO_VOL_RATIO, e.g. 1/4). Optional caller-defined settings:
+;   NO_FIRST_VOL: skip the initial HI_VOL volume/duty command (e.g. if already set)
+;   CHANNEL: set to 4 to use "duty" instead of "vol" for the volume commands (wave channel)
+;   NOTE_MID_WAIT / NOTE_END_WAIT: carve a rest out of the end of the HI_VOL / LO_VOL portion
+; Following a note/length pair with "r <length>" extends the rest at the end of that note.
+;	vol $6
+;	beat a 1
+;	vol $3
+;	beat a 1
+;
+;	volbeat a 2
+.macro volbeat
+	.ifndef HI_VOL
+		.define HI_VOL 0
+	.endif
+
+	.ifndef LO_VOL
+		.define LO_VOL 0
+	.endif
+
+	.ifndef NO_FIRST_VOL
+		.define NO_FIRST_VOL 0
+	.endif
+
+	.ifndef REST
+		.define REST 0
+	.endif
+	.redefine REST 0
+
+	.ifndef CHANNEL
+		.define CHANNEL 0
+	.endif
+	.ifndef NOTE_MID_WAIT
+		.define NOTE_MID_WAIT 0
+	.endif
+
+	.ifndef NOTE_END_WAIT
+		.define NOTE_END_WAIT 0
+	.endif
+
+	.redefine offset 0
+	.rept NARGS
+	.if NARGS >= 1
+		.if \1 == od
+			octaved
+			.redefine offset offset-12
+			.shift
+		.else
+		.if \1 == ou
+			octaveu
+			.redefine offset offset+12
+			.shift
+		.endif
+		.endif
+	.endif
+
+	.if NARGS >= 2
+	.if \1 == r
+		rest \2*BEAT
+		.shift
+		.shift
+	.else
+	.if \1 >= 0
+		; First volume change
+		.if NO_FIRST_VOL == 0
+			.if CHANNEL == 4
+				duty HI_VOL
+			.else
+				vol HI_VOL
+			.endif
+		.endif
+
+		; First note
+		.db \1+offset
+
+		.redefine LO_LENGTH ((\2*BEAT)-((\2*BEAT)#(1/LO_VOL_RATIO)))*LO_VOL_RATIO
+		.if ((\2*BEAT)#(1/LO_VOL_RATIO)) >= 0.5/LO_VOL_RATIO
+			.redefine LO_LENGTH LO_LENGTH + 1
+		.endif
+		.redefine HI_LENGTH (\2*BEAT)-LO_LENGTH
+
+		.if NOTE_MID_WAIT != 0
+			.db HI_LENGTH - NOTE_MID_WAIT
+			rest NOTE_MID_WAIT
+		.else
+			.db HI_LENGTH
+		.endif
+
+		; Second volume change
+		.if CHANNEL == 4
+			duty LO_VOL
+		.else
+			vol LO_VOL
+		.endif
+
+		; Second note
+		.db \1+offset
+
+		.if NARGS >= 4
+			.if \3 == r
+				.redefine REST \4*BEAT
+			.endif
+		.endif
+
+		.if NOTE_END_WAIT != 0
+			.db LO_LENGTH - (NOTE_END_WAIT + REST)
+			rest NOTE_END_WAIT + REST
+		.else
+			.db LO_LENGTH
+		.endif
+
+		.if NARGS >= 4
+			.if \3 == r
+				.if NOTE_END_WAIT == 0
+					rest REST
+				.endif
+				.shift
+				.shift
+			.endif
+		.endif
+
+		.shift
+		.shift
+	.endif
+	.endif
+	.endif
+	.endr
+.endm
+
+; Used for alternating two notes with a volume dip on each, e.g. Tarm Ruins' music. Call
+; repeatedly with one note/length pair per call; each call plays the *previous* call's note at
+; LO_VOL for its tail (via TARM_NOTE) before the current note's HI_VOL attack, except the first
+; call which only plays its own note.
+;	vol HI_VOL
+;	beat a 12
+;	rest 12
+;
+;	beat b 12
+;	vol LO_VOL
+;	beat a 12
+;
+;	vol HI_VOL
+;	beat c 12
+;	vol LO_VOL
+;	beat b 12
+;
+;	tarmbeat a 24 b 24 c 24
+.macro tarmbeat
+	.redefine offset 0
+	.rept NARGS
+	.if NARGS >= 1
+		.if \1 == od
+			octaved
+			.redefine offset offset-12
+			.shift
+		.else
+		.if \1 == ou
+			octaveu
+			.redefine offset offset+12
+			.shift
+		.endif
+		.endif
+	.endif
+
+	.if NARGS >= 2
+	.if \1 == r
+		rest \2*BEAT
+		.shift
+		.shift
+	.else
+	.if \1 >= 0
+		.ifndef HI_VOL
+			.define HI_VOL 0
+		.endif
+
+		.ifndef LO_VOL
+			.define LO_VOL 0
+		.endif
+
+		.ifndef NO_FIRST_VOL
+			.define NO_FIRST_VOL 0
+		.endif
+
+		.ifndef CHANNEL
+			.define CHANNEL 0
+		.endif
+
+		.ifndef TARM_NOTE
+			.define TARM_NOTE 0
+		.endif
+
+		; First volume change
+		.if NO_FIRST_VOL == 0
+			.if CHANNEL == 4
+				duty HI_VOL
+			.else
+				vol HI_VOL
+			.endif
+		.endif
+		; First note
+		.db \1+offset
+		.db \2*BEAT*(1-LO_VOL_RATIO)
+
+		; Second volume change
+		.if TARM_NOTE != 0
+			.if CHANNEL == 4
+				duty LO_VOL
+			.else
+				vol LO_VOL
+			.endif
+
+			; Second note
+			.db TARM_NOTE
+			.db \2*BEAT*LO_VOL_RATIO
+			.redefine NO_FIRST_VOL 0
+		.else
+			rest \2*BEAT*LO_VOL_RATIO
+			.redefine NO_FIRST_VOL 1
+		.endif
+
+		.redefine TARM_NOTE \1+offset
+
+		.shift
+		.shift
+	.endif
+	.endif
+	.endif
+	.endr
+.endm
+
 ; 60: rest, stops playing the previous note and sets wait counter
 .macro rest
 	.db $60 \1

--- a/include/musicMacros.s
+++ b/include/musicMacros.s
@@ -227,8 +227,9 @@
 	.db $60 \1
 .endm
 
-; 61: wait without changing the previous note or rest, can be used to extend a note or rest (for channels 0-3)
-.macro rest2 ; Unused?
+; 61: extends the currently playing note/rest without retriggering or otherwise
+;     affecting it. this is a tie/sustain, not a rest.
+.macro sust
 	.db $61 \1
 .endm
 
@@ -240,16 +241,17 @@
 	.db $d0 | \1
 .endm
 
-; e0-e7: set envelopes (for channels 0-3)
+; e0-e7: set envelope (\1 $0-$7: software-simulated attack envelope speed, starting at volume 1 and
+;        snapping to the note's target volume after a fixed delay)
+;        and increasing to volume 15 entirely in hardware at the given speed (\1 & $7)
+; \2 ($0-$7 either way): decay speed -- an exact hardware envelope match in both cases,
+;        decreasing from the note's target volume to 0
 .macro env
-	.if \1 > $7
 		.fail
 	.endif
 	.db $e0 | \1
 	.db \2
 .endm
-
-; e8-ef: same as e0-e7
 
 ; f0: does various things for channels 0-5, sets volume and envelope for channel 7, see audio.s for details
 .macro cmdf0
@@ -258,6 +260,7 @@
 
 ; f1-f3: does nothing
 .macro cmdf1
+; f1-f3: Unused as bare no-op bytes by every vanilla song: may be repurposed (patternCall / patternEnd, perhaps?)
 	.db $f1
 .endm
 .macro cmdf2
@@ -282,8 +285,10 @@
 
 ; f7: duplicate of ff
 
-; f8: sets sweep (for channels 0-5)
 .macro cmdf8
+; single frame for as long as it stays nonzero, so the pitch keeps sliding
+; indefinitely rather than settling on a target. Use pitchSlide $00
+; to stop an ongoing slide.
 	.db $f8 \1
 .endm
 
@@ -296,9 +301,11 @@
 
 ; fa-fc: duplicates of ff
 
-; fd: sets wChannelPitchShift (for channels 0-5)
-; Shifts pitch
-.macro cmdfd
+; fd: flat pitch offset (channels 0-5 only, i.e. pulse/wave, both the music
+; and sfx slots; a no-op on noise, 6-7). \1 is a signed byte, added once to the frequency
+; every time a note triggers on this channel and held constant for that note's whole duration.
+; Use pitchOffset $00 to disable again.
+.macro pitchOffset
 	.db $fd \1
 .endm
 

--- a/include/musicMacros.s
+++ b/include/musicMacros.s
@@ -295,10 +295,9 @@
 
 ; f8: continuous pitch slide (channels 0-5 only). \1 is a signed byte, re-added to the note's frequency every
 ; single frame for as long as it stays nonzero, so the pitch keeps sliding
-; indefinitely rather than settling on a target. Use pitchSlide $00
 ; indefinitely rather than settling on a target (the latter behavior would be "portamento")
-; Use "cmdf8 $00" to stop an ongoing slide.
-.macro cmdf8
+; Use "pitchSlide $00" to stop an ongoing slide.
+.macro pitchSlide
 	.db $f8 \1
 .endm
 

--- a/include/musicMacros.s
+++ b/include/musicMacros.s
@@ -277,7 +277,6 @@
 .endm
 
 ; f4-f5: duplicates of ff
-; f4-f5: duplicates of ff?
 .macro cmdf4
 	.db $f4
 .endm

--- a/include/musicMacros.s
+++ b/include/musicMacros.s
@@ -262,12 +262,10 @@
 	.db $f0 \1
 .endm
 
-; f1/f3: pattern-call / pattern-end (editable-build only -- see code/audio.s). Confirmed
-; unused as bare no-op bytes by every vanilla song, which is what let them be repurposed.
-.macro patternCall
+; f1-f3: does nothing
+.macro cmdf1
+; f1-f3: Unused as bare no-op bytes by every vanilla song: may be repurposed (patternCall / patternEnd, perhaps?)
 	.db $f1
-	.dw \1
-	.db \2
 .endm
 .macro cmdf2
 	.db $f2

--- a/include/musicMacros.s
+++ b/include/musicMacros.s
@@ -229,6 +229,8 @@
 
 ; 61: extends the currently playing note/rest without retriggering or otherwise
 ;     affecting it. this is a tie/sustain, not a rest.
+;	  the existing rest macro (60) is bugged: it behaves like a sustain, so they are both coded to sustain the note.
+;	  this true sustain command is unused in all vanilla songs, utilizing cmd60 (rest) for all of its wait durations between notes.
 .macro sust
 	.db $61 \1
 .endm
@@ -247,21 +249,25 @@
 ; \2 ($0-$7 either way): decay speed -- an exact hardware envelope match in both cases,
 ;        decreasing from the note's target volume to 0
 .macro env
+	.if \1 > $f
 		.fail
 	.endif
 	.db $e0 | \1
 	.db \2
 .endm
 
-; f0: does various things for channels 0-5, sets volume and envelope for channel 7, see audio.s for details
+; f0: unknown
+; Sometimes sets wc039
 .macro cmdf0
 	.db $f0 \1
 .endm
 
-; f1-f3: does nothing
-.macro cmdf1
-; f1-f3: Unused as bare no-op bytes by every vanilla song: may be repurposed (patternCall / patternEnd, perhaps?)
+; f1/f3: pattern-call / pattern-end (editable-build only -- see code/audio.s). Confirmed
+; unused as bare no-op bytes by every vanilla song, which is what let them be repurposed.
+.macro patternCall
 	.db $f1
+	.dw \1
+	.db \2
 .endm
 .macro cmdf2
 	.db $f2
@@ -271,6 +277,7 @@
 .endm
 
 ; f4-f5: duplicates of ff
+; f4-f5: duplicates of ff?
 .macro cmdf4
 	.db $f4
 .endm
@@ -285,10 +292,13 @@
 
 ; f7: duplicate of ff
 
-.macro cmdf8
+
+; f8: continuous pitch slide (channels 0-5 only). \1 is a signed byte, re-added to the note's frequency every
 ; single frame for as long as it stays nonzero, so the pitch keeps sliding
 ; indefinitely rather than settling on a target. Use pitchSlide $00
-; to stop an ongoing slide.
+; indefinitely rather than settling on a target (the latter behavior would be "portamento")
+; Use "cmdf8 $00" to stop an ongoing slide.
+.macro cmdf8
 	.db $f8 \1
 .endm
 

--- a/include/wram.s
+++ b/include/wram.s
@@ -96,7 +96,7 @@ wChannelFrequencyModeAndLengthTimerEnabled: ; $c039
 ; This does two things:
 ; If not 0, the standard audio command is not treated as an index into soundFrequencyTable,
 ; but as the high byte for a frequency value, and the next byte is treated as the lower byte, followed by the length
-; For square channels, if bit 6 is set, then that bit also gets set on updates to wSoundCmdEnvelope
+; For pulse channels, if bit 6 is set, then that bit also gets set on updates to wSoundCmdEnvelope
 ; which enables the length timer for the channel (the initial length timer comes from wChannelDutyCycles)
 	dsb 6
 

--- a/tools/dump/dumpMusic.py
+++ b/tools/dump/dumpMusic.py
@@ -198,10 +198,14 @@ def parseChannelData(address, channel, chanOut):
             param = rom[address]
             address+=1
             chanOut.write('\tpitchSlide ' + wlahex(param,2) + '\n')
-        elif b == 0xf9 or b == 0xfd:
+        elif b == 0xf9:
             param = rom[address]
             address+=1
             chanOut.write('\tcmd' + myhex(b) + ' ' + wlahex(param,2) + '\n')
+        elif b == 0xfd:
+            param = rom[address]
+            address += 1
+            chanOut.write('\tpitchOffset ' + wlahexSigned(param,2) + '\n')
         elif b >= 0xf0:
             chanOut.write('\tcmd' + myhex(b) + '\n')
         elif b >= 0xe0:

--- a/tools/dump/dumpMusic.py
+++ b/tools/dump/dumpMusic.py
@@ -190,7 +190,15 @@ def parseChannelData(address, channel, chanOut):
             chanOut.write('\tcmdf0 ' + wlahex(param,2) + '\n')
             if channel != 7:
                 c039 = 1
-        elif b == 0xf0 or b == 0xf6 or b == 0xf8 or b == 0xf9 or b == 0xfd:
+        elif b == 0xf0 or b == 0xf6:
+            param = rom[address]
+            address+=1
+            chanOut.write('\tcmd' + myhex(b) + ' ' + wlahex(param,2) + '\n')
+        elif b == 0xf8:
+            param = rom[address]
+            address+=1
+            chanOut.write('\tpitchSlide ' + wlahex(param,2) + '\n')
+        elif b == 0xf9 or b == 0xfd:
             param = rom[address]
             address+=1
             chanOut.write('\tcmd' + myhex(b) + ' ' + wlahex(param,2) + '\n')


### PR DESCRIPTION
## Summary

Port the following audio macros into `include/musicMacros.s`, [from ZerotoKoops' music repo](https://github.com/ZerotoKoops/custom-channelData/tree/master/disasmCode/):

* `tempo` for defining note lengths from a BPM value
* `m_splitLength` for subdividing note lengths into arbitrary timing divisions

These macros are additive and self-contained, and are intended for compatibility with older songs created using these macros, which are now also hosted on the [Custom Music wiki page](https://wiki.zeldahacking.net/oracle/Custom_Music).

No changes to `wram.s` or `audio.s` are required, as these macros only provide timing functionality and do not introduce any new audio engine commands.

## Details

### `tempo`

Given a BPM value, calculates `Q` (frames per beat) and provides a set of eighth-note and twelfth-note length constants, along with their common groupings. This allows songs to specify note lengths using real musical divisions rather than manually calculated frame counts.

It also sets `BEAT` to `1`.

### `m_splitLength`

Provides a way to subdivide note lengths into arbitrary timing divisions that aren't covered by the built-in `tempo` groupings.

This is retained because it is needed for compatibility with songs using the original timing macros.

## Deliberately excluded

The following macros from the external source are **not** being ported:

* `noteLen`
* `volbeat`
* `tarmbeat`
* `echobeat`
* `volbeat2`
* `volbeat3`

The associated volume, duty, echo, and phrasing functionality is outside the scope of this port.

The older `wram.s` / `audio.s` changes from the external source are also excluded, including renamed labels, outdated comments, the old `$72` bank workaround, and the `cmdf8`/`cmdfd`/`gotoCond`/`incCoda` naming. These changes predate the current branch's engine and documentation work and should not be brought forward.